### PR TITLE
Fix episode listing

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -94,8 +94,8 @@ def episode(series_id, season_id):
         Log.Critical(e.message)
         return MessageContainer(S("error"), e.message)
     request = r.json()
-    series_title = request[0]["series"]["title"]
-    oc = ObjectContainer(title2=series_title)
+    current_season = "Season " + season_id
+    oc = ObjectContainer(title2=current_season)
     # for e in reversed(request):
     # for e in reversed(request):
     for e in sorted(request, key=lambda x: x["episodeNumber"], reverse=True):


### PR DESCRIPTION
This is a fix or Issue #10, where you get a "not responding" message when trying to list episodes.

The problem was the data being looked for in JSON (series title) doesn't exist. I swapped this out to instead use the Season # as the view title in Plex.
