### PR TITLE
Fixed image URL for Series List

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -426,7 +426,7 @@ def series():
                              summary=summary)
         for coverType in s["images"]:
             if coverType["coverType"] == "poster":
-                do.thumb = Callback(get_thumb, url=endpoint + coverType["url"])
+                do.thumb = Callback(get_thumb, url=apiUrl + coverType["url"] + "&apikey=" + Prefs["apiKey"])
                 break
         oc.add(do)
     return oc


### PR DESCRIPTION
If Sonarr has any form of auth enabled, the images won't be accessible.

This grabs the images from API endpoint, with API key instead.

This should fix bug #12.
