### PR TITLE
Fixes issue #7 (Add series missing in new Plex clients #7)

### DIFF
--- a/Contents/Code/DumbTools.py
+++ b/Contents/Code/DumbTools.py
@@ -1,0 +1,184 @@
+# DumbTools for Plex v1.1 by Cory <babylonstudio@gmail.com>
+import urllib2
+
+
+class DumbKeyboard:
+    clients = ['Plex for iOS', 'Plex Media Player', 'Plex Web']
+    KEYS = list('abcdefghijklmnopqrstuvwxyz1234567890-=;[]\\\',./')
+    SHIFT_KEYS = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+:{}|\"<>?')
+
+    def __init__(self, prefix, oc, callback, dktitle=None, dkthumb=None,
+                 dkplaceholder=None, dksecure=False, **kwargs):
+        cb_hash = hash(str(callback)+str(kwargs))
+        Route.Connect(prefix+'/dumbkeyboard/%s'%cb_hash, self.Keyboard)
+        Route.Connect(prefix+'/dumbkeyboard/%s/submit'%cb_hash, self.Submit)
+        Route.Connect(prefix+'/dumbkeyboard/%s/history'%cb_hash, self.History)
+        Route.Connect(prefix+'/dumbkeyboard/%s/history/clear'%cb_hash, self.ClearHistory)
+        Route.Connect(prefix+'/dumbkeyboard/%s/history/add/{query}'%cb_hash, self.AddHistory)
+        # Add our directory item
+        oc.add(DirectoryObject(key=Callback(self.Keyboard, query=dkplaceholder),
+                               title=str(dktitle) if dktitle else \
+                                     u'%s'%L('DumbKeyboard Search'),
+                               thumb=dkthumb))
+        # establish our dict entry
+        if 'DumbKeyboard-History' not in Dict:
+            Dict['DumbKeyboard-History'] = []
+            Dict.Save()
+        self.Callback = callback
+        self.callback_args = kwargs
+        self.secure = dksecure
+
+    def Keyboard(self, query=None, shift=False):
+        if self.secure and query is not None:
+            string = ''.join(['*' for i in range(len(query[:-1]))]) + query[-1]
+        else:
+            string = query if query else ""
+
+        oc = ObjectContainer()
+        # Submit
+        oc.add(DirectoryObject(key=Callback(self.Submit, query=query),
+                               title=u'%s: %s'%(L('Submit'), string.replace(' ', '_'))))
+        # Search History
+        if Dict['DumbKeyboard-History']:
+            oc.add(DirectoryObject(key=Callback(self.History),
+                                   title=u'%s'%L('Search History')))
+        # Space
+        oc.add(DirectoryObject(key=Callback(self.Keyboard,
+                                            query=query+" " if query else " "),
+                               title='Space'))
+        # Backspace (not really needed since you can just hit back)
+        if query is not None:
+            oc.add(DirectoryObject(key=Callback(self.Keyboard, query=query[:-1]),
+                                   title='Backspace'))
+        # Shift
+        oc.add(DirectoryObject(key=Callback(self.Keyboard, query=query, shift=True),
+                               title='Shift'))
+        # Keys
+        for key in self.KEYS if not shift else self.SHIFT_KEYS:
+            oc.add(DirectoryObject(key=Callback(self.Keyboard,
+                                                query=query+key if query else key),
+                                   title=u'%s'%key))
+        return oc
+
+    def History(self):
+        oc = ObjectContainer()
+        if Dict['DumbKeyboard-History']:
+            oc.add(DirectoryObject(key=Callback(self.ClearHistory),
+                                   title=u'%s'%L('Clear History')))
+        for item in Dict['DumbKeyboard-History']:
+            oc.add(DirectoryObject(key=Callback(self.Submit, query=item),
+                                   title=u'%s'%item))
+        return oc
+
+    def ClearHistory(self):
+        Dict['DumbKeyboard-History'] = []
+        Dict.Save()
+        return self.History()
+
+    def AddHistory(self, query):
+        if query not in Dict['DumbKeyboard-History']:
+            Dict['DumbKeyboard-History'].append(query)
+            Dict.Save()
+
+    def Submit(self, query):
+        self.AddHistory(query)
+        kwargs = {'query': query}
+        kwargs.update(self.callback_args)
+        return self.Callback(**kwargs)
+
+
+class DumbPrefs:
+    clients = ['Plex for iOS', 'Plex Media Player', 'Plex Home Theater',
+               'OpenPHT', 'Plex for Roku']
+
+    def __init__(self, prefix, oc, title=None, thumb=None):
+        self.host = 'http://127.0.0.1:32400'
+        try:
+            self.CheckAuth()
+        except Exception as e:
+            Log.Error('DumbPrefs: this user cant access prefs: %s' % str(e))
+            return
+
+        Route.Connect(prefix+'/dumbprefs/list', self.ListPrefs)
+        Route.Connect(prefix+'/dumbprefs/listenum', self.ListEnum)
+        Route.Connect(prefix+'/dumbprefs/set', self.Set)
+        Route.Connect(prefix+'/dumbprefs/settext',  self.SetText)
+        oc.add(DirectoryObject(key=Callback(self.ListPrefs),
+                               title=title if title else L('Preferences'),
+                               thumb=thumb))
+        self.prefix = prefix
+        self.GetPrefs()
+
+    def GetHeaders(self):
+        headers = Request.Headers
+        headers['Connection'] = 'close'
+        return headers
+
+    def CheckAuth(self):
+        """ Only the main users token is accepted at /myplex/account """
+        headers = {'X-Plex-Token': Request.Headers.get('X-Plex-Token', '')}
+        req = urllib2.Request("%s/myplex/account" % self.host, headers=headers)
+        res = urllib2.urlopen(req)
+
+    def GetPrefs(self):
+        data = HTTP.Request("%s/:/plugins/%s/prefs" % (self.host, Plugin.Identifier),
+                            headers=self.GetHeaders())
+        prefs = XML.ElementFromString(data).xpath('/MediaContainer/Setting')
+
+        self.prefs = [{'id': pref.xpath("@id")[0],
+                       'type': pref.xpath("@type")[0],
+                       'label': pref.xpath("@label")[0],
+                       'default': pref.xpath("@default")[0],
+                       'secure': True if pref.xpath("@secure")[0] == "true" else False,
+                       'values': pref.xpath("@values")[0].split("|") \
+                                 if pref.xpath("@values") else None
+                      } for pref in prefs]
+
+    def Set(self, key, value):
+        HTTP.Request("%s/:/plugins/%s/prefs/set?%s=%s" % (self.host,
+                                                          Plugin.Identifier,
+                                                          key, value),
+                     headers=self.GetHeaders(),
+                     immediate=True)
+        return ObjectContainer()
+
+    def ListPrefs(self):
+        oc = ObjectContainer(no_cache=True)
+        for pref in self.prefs:
+            do = DirectoryObject()
+            value = Prefs[pref['id']] if not pref['secure'] else \
+                    ''.join(['*' for i in range(len(Prefs[pref['id']]))])
+            title = u'%s: %s = %s' % (L(pref['label']), pref['type'], L(value))
+            if pref['type'] == 'enum':
+                do.key = Callback(self.ListEnum, id=pref['id'])
+            elif pref['type'] == 'bool':
+                do.key = Callback(self.Set, key=pref['id'],
+                                  value=str(not Prefs[pref['id']]).lower())
+            elif pref['type'] == 'text':
+                if Client.Product in DumbKeyboard.clients:
+                    DumbKeyboard(self.prefix, oc, self.SetText,
+                                 id=pref['id'],
+                                 dktitle=title,
+                                 dkplaceholder=Prefs[pref['id']],
+                                 dksecure=pref['secure'])
+                else:
+                    oc.add(InputDirectoryObject(key=Callback(self.SetText, id=pref['id']),
+                                                title=title))
+                continue
+            else:
+                do.key = Callback(self.ListPrefs)
+            do.title = title
+            oc.add(do)
+        return oc
+
+    def ListEnum(self, id):
+        oc = ObjectContainer()
+        for pref in self.prefs:
+            if pref['id'] == id:
+                for i, option in enumerate(pref['values']):
+                    oc.add(DirectoryObject(key=Callback(self.Set, key=id, value=i),
+                                           title=u'%s'%option))
+        return oc
+
+    def SetText(self, query, id):
+        return self.Set(key=id, value=query)

--- a/Contents/Code/DumbTools_README.md
+++ b/Contents/Code/DumbTools_README.md
@@ -1,0 +1,105 @@
+# DumbKeyboard
+
+This serves as a replacement for the InputDirectoryObject in the Plex Plug-in framework for clients that don't support it. It uses DirectoryObjects to build a query string, then lets you send that to the Search function. Search queries are saved in the channels Dict so they don't need to be re-entered.
+
+![img](http://i.imgur.com/y4smv7P.png)
+![http://i.imgur.com/Q622vhM.png](http://i.imgur.com/Q622vhM.png)
+
+### Usage:
+
+add `DumbTools.py` to `Channel.bundle/Contents/Code`.
+
+in `__init__.py` add:
+```
+from DumbTools import DumbKeyboard
+```
+
+in `__init__.py` where you have an InputDirectoryObject:
+```python
+if Client.Product in DumbKeyboard.clients:
+        DumbKeyboard(PREFIX, oc, Search,
+                dktitle = u'%s' L('search'),
+                dkthumb = R(ICONS['search'])
+        )
+else:
+        oc.add(InputDirectoryObject(
+                key    = Callback(Search),
+                title  = u'%s' L('search'),
+                prompt = 'Search',
+                thumb  = R(ICONS['search'])
+        ))
+        
+@route(PREFIX + '/search')
+def Search(query):
+        ...
+```        
+### Definitions:
+
+`DumbKeyboard(prefix, oc, callback, dktitle=None, dkthumb=None, dkplaceholder=None, dksecure=False, **kwargs)`
+
+Appends a DirectoryObject to `oc` which will provide a series of DirectoryObjects to build a string. `callback` is called with the arguments `query` and `**kwargs` when the Submit directory is selected.
+
+  * *prefix*: whatever is used in the @handler(PREFIX, NAME).
+  * *oc*: the object container to add to.
+  * *callback*: the Search function. This must have atleast 1 argument 'query'.
+  * *dktitle*: (optional) the title to use for the search directoryObject.
+  * *dkthumb*: (optional) the thumbnail to use for the search directoryObject.
+  * *dkplaceholder*: (optional) set a default value in the text entry.
+  * *dksecure*: (optional) set the entry to be secure or not (show *'s instead of the characters).
+  * ***kwargs*: additional arguments to send to the callback function.
+    * if you have search function `Search(query, a=None, b=None)` then you can use `DumbKeyboard(prefix, oc, Search, a='something' b=123)`
+ 
+`DumbKeyboard.clients` - Client.Product's that don't have InputDirectoryObjects or don't always work correctly.
+  * Plex for iOS
+  * Plex Media Player
+  * Plex Web
+
+# DumbPrefs
+
+a replacement for the PrefsObject. This should allow both displaying and changing channel preferences using only DirectoryObjects.
+
+![http://i.imgur.com/fI65O87.png](http://i.imgur.com/fI65O87.png)
+
+It may require the following addition to `Info.plist`:
+```xml
+    <key>PlexPluginCodePolicy</key>
+    <string>Elevated</string>
+```
+
+### Usage:
+
+```python
+from DumbTools import DumbPrefs
+
+@handler(PREFIX, NAME)
+def MainMenu():
+        oc = ObjectContainer()
+        
+        if Client.Product in DumbPrefs.clients:
+                DumbPrefs(PREFIX, oc,
+                        title = L('preferences'),
+                        thumb = R(ICONS['preferences']))
+        else:
+                oc.add(PrefsObject(
+                        title = L('preferences'),
+                        thumb = R(ICONS['preferences'])
+                ))
+```
+
+### Definitions: 
+
+`DumbPrefs(prefix, oc, title=None, thumb=None)`
+
+Appends a DirectoryObject to `oc` which will allow users to change text, bool, and enum channel preferences.
+
+  * *prefix*: whatever is used in the @handler(PREFIX, NAME).
+  * *oc*: the object container to add to.
+  * *title*: (optional) the title to use for the directoryObject.
+  * *thumb*: (optional) the thumbnail to use for the directoryObject.
+
+`DumbPrefs.clients` - Client.Product's that don't have Prefs or don't always work correctly.
+  * 'Plex for iOS' - doesn't have it
+  * 'Plex Media Player' - doesn't have it
+  * 'Plex Home Theater' - has it, but it never liked saving text prefs
+  * 'OpenPHT'
+  * 'Plex for Roku' - I don't think it has it, I'm not sure if this is the correct product name.

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,5 +1,6 @@
 # from mock_framework import *
 from datetime import datetime
+from DumbTools import DumbKeyboard
 import requests
 
 PREFIX = "/video/sonarr"
@@ -414,8 +415,11 @@ def series():
         Log.Critical(e.message)
         return MessageContainer(S("error"), e.message)
     oc = ObjectContainer(title2="Series")
-    oc.add(InputDirectoryObject(key=Callback(series_lookup), title=S("addSeries"), summary=S("addSeriesSummary"),
-                                thumb=R("search.png"), prompt=S("search")))
+    if Client.Product in DumbKeyboard.clients:
+        DumbKeyboard(PREFIX, oc, series_lookup, dktitle=S("addSeries"), dkthumb=R("search.png"))
+    else:
+        oc.add(InputDirectoryObject(key=Callback(series_lookup), title=S("addSeries"), summary=S("addSeriesSummary"),
+                                    thumb=R("search.png"), prompt=S("search")))
     for s in sorted(r.json(), key=lambda x: x["sortTitle"]):
         title = s["title"]
         series_id = s["id"]


### PR DESCRIPTION
Utilizes DumbTools by coryo to add an interface that can be used to add new series from the numerous devices that don't support InputDirectoryObject: https://github.com/coryo/DumbTools-for-Plex
